### PR TITLE
Run "pdl2" as boot_command in PDL mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.bin
+*.o
+*.su
+.boards.depend
+.depend
+.depend.*

--- a/include/configs/rda_config_defaults.h
+++ b/include/configs/rda_config_defaults.h
@@ -277,11 +277,15 @@
 	"root=/dev/ram rw "		\
 	"rdinit=/init"
 
+#ifdef CONFIG_RDA_PDL
+#define CONFIG_BOOTCOMMAND "mux_config; pdl2;"
+#else /* CONFIG_RDA_PDL */
 #define CONFIG_BOOTCOMMAND		\
 	"mux_config; "		\
 	"mmc dev 0; "		\
 	"ext2load mmc 0:1 ${script_addr} boot.scr && source ${script_addr};" \
 	"echo Running boot script failed;"
+#endif /* CONFIG_RDA_PDL */
 
 #endif /* !CONFIG_SPL_BUILD */
 

--- a/include/configs/rda_config_defaults.h
+++ b/include/configs/rda_config_defaults.h
@@ -277,6 +277,8 @@
 	"root=/dev/ram rw "		\
 	"rdinit=/init"
 
+#define CONFIG_PREBOOT "mtdparts default;"
+
 #ifdef CONFIG_RDA_PDL
 #define CONFIG_BOOTCOMMAND "mux_config; pdl2;"
 #else /* CONFIG_RDA_PDL */


### PR DESCRIPTION
U-Boot currently attempts normal boot when compiled, uploaded and executed as pdl2.bin. This fixes that.